### PR TITLE
Prints the CMSSW version used for the submissions in the description

### DIFF
--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -696,7 +696,11 @@ def printInfo(options):
     f = open(hltFilename)
     menu = f.readline()
     menu = menu.replace('\n','').replace('# ','')
-  
+    menulist = menu.split()
+    hltCmsswVersion = (options.hltCmsswDir).split('/')
+    menulist[-1] = '(%s)'%(hltCmsswVersion[-1]) 
+    menu = menulist[0] + " " + menulist[-1]
+
   matched=re.match("(.*),(.*),(.*)",options.newgt)
   if matched: 
     newgtshort=matched.group(1)


### PR DESCRIPTION
@franzoni @mmusich
It prints like this in the description now : 

HLT menu: /cdaq/physics/Run2016/25ns15e33/v3.1.1/HLT/V1 (CMSSW_8_0_16)

the CMSSW version is the one used for the submissions.
